### PR TITLE
fix: Added 'zod' package and resolved 'Cannot find module' error with tsconfig-paths in tutorial

### DIFF
--- a/docs/tutorial/frourio.mdx
+++ b/docs/tutorial/frourio.mdx
@@ -88,7 +88,7 @@ cp ../src/api/hi/index.ts api/hi
 さて、frourio サーバーを起動しましょう！
 
 ```sh title=Terminal
-yarn ts-node index.ts
+yarn ts-node --require tsconfig-paths/register index.ts
 ```
 
 念のため、サーバーが以前と同じように動いているか確認しましょう。

--- a/docs/tutorial/preparation.mdx
+++ b/docs/tutorial/preparation.mdx
@@ -20,8 +20,8 @@ cd frourio-tutorial
 mkdir server
 cd server
 yarn init -y
-yarn add fastify @fastify/cors
-yarn add -D typescript ts-node @types/node
+yarn add fastify @fastify/cors zod
+yarn add -D typescript ts-node @types/node tsconfig-paths
 ```
 
 ## 3. Fastify サーバーの作成 {#create-fastify-server}
@@ -51,7 +51,8 @@ fastify.listen({ port: 8888, host: '0.0.0.0' });
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "baseUrl": "."
   },
   "exclude": ["node_modules"],
   "include": ["**/*.ts"]


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->

Issue Number: N/A（Issueはありません）

<!--- Describe your changes in detail. -->

https://ja.frourio.com/docs/tutorial/frourio#start-frourio-server
上記のチュートリアルのfrourioサーバーを起動する際、コマンドを実行したところ、エラーが発生しました。
```sh title=Terminal
yarn ts-node index.ts
```
<img width="1023" alt="スクリーンショット 2024-04-05 22 20 53" src="https://github.com/frouriojs/ja.frourio.com/assets/73740965/5ff5ac4d-d2f5-4f1c-aaaf-e3337455a4e6">

- エラーの一つは、zodがinstallできていなかったことから、zodをinstallするよう追記しました。
- エラーのもう一つは、`$server.ts`で`api/controller`が見つけられていなかったことから、baseUrlの指定とtsconfig-pathsを使用することでエラー解消できましたので追記しました。

よろしくお願いいたします。
